### PR TITLE
Fixing text-anchor issue for IE11 Should not be 'left' it should be '…

### DIFF
--- a/src/js/header.js
+++ b/src/js/header.js
@@ -2,12 +2,12 @@
  * D3.EZ
  * 
  * @author James Saunders [james@saunders-family.net]
- * @copyright Copyright (C) 2015 James Saunders
+ * @copyright Copyright (C) 2017 James Saunders
  * @license GPLv3
  */
 d3.ez = {
     version: "1.5.9",
     author: "James Saunders",
-    copyright: "Copyright (C) 2015 James Saunders",
+    copyright: "Copyright (C) 2017 James Saunders",
     license: "GPL-3.0"
 };

--- a/src/js/reusableComponents.js
+++ b/src/js/reusableComponents.js
@@ -37,7 +37,7 @@ d3.ez.labeledNode = function module() {
             .text(label)
             .attr("dx", r + 2)
             .attr("dy", r + 6)
-            .style("text-anchor", "left")
+            .style("text-anchor", "start")
             .style("font-size", fontSize + "px")
             .attr("class", "nodetext");
     }


### PR DESCRIPTION
…start'.